### PR TITLE
Invoke seeder on every MonteCarlo::reset()

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -10,7 +10,7 @@
 
 no::Model::Model(no::Timeline& timeline, const py::function& seeder)
     : m_runState(no::Model::NOT_STARTED), m_timeline(timeline), m_timeline_handle(py::cast(&timeline)),
-      m_monteCarlo(seeder().cast<int32_t>()) {
+      m_monteCarlo([seeder]() { return seeder().cast<int32_t>(); }) {
   no::log("model init: timeline=%% mc=%%"s % m_timeline.repr() % m_monteCarlo.repr());
 }
 

--- a/src/MonteCarlo.cpp
+++ b/src/MonteCarlo.cpp
@@ -45,7 +45,7 @@ int32_t no::MonteCarlo::nondeterministic_stream() noexcept {
   return rand();
 }
 
-no::MonteCarlo::MonteCarlo(int32_t seed) noexcept : m_seed(seed), m_prng(m_seed) {}
+no::MonteCarlo::MonteCarlo(std::function<int32_t()> seeder) noexcept : m_seeder(std::move(seeder)), m_seed(m_seeder()), m_prng(m_seed) {}
 
 int32_t no::MonteCarlo::seed() const noexcept { return m_seed; }
 
@@ -58,7 +58,7 @@ void no::MonteCarlo::init_bitgen(py::capsule capsule) {
   bitgen->next_raw = [](void* p) { return static_cast<no::MonteCarlo*>(p)->raw(); };
 }
 
-void no::MonteCarlo::reset() noexcept { m_prng.seed(m_seed); }
+void no::MonteCarlo::reset() noexcept { m_seed = m_seeder(); m_prng.seed(m_seed); }
 
 std::string no::MonteCarlo::repr() const noexcept { return "<neworder.MonteCarlo seed=%%>"s % seed(); }
 

--- a/src/MonteCarlo.h
+++ b/src/MonteCarlo.h
@@ -23,8 +23,8 @@ public:
 
   static int32_t nondeterministic_stream() noexcept;
 
-  // constructs given a seed
-  MonteCarlo(int32_t seed) noexcept;
+  // constructs given a seeder callable, invoked on construction and on each reset()
+  MonteCarlo(std::function<int32_t()> seeder) noexcept;
 
   void init_bitgen(py::capsule capsule);
 
@@ -77,6 +77,7 @@ private:
   // Use this over std::uniform_real_distribution as can make C++ and rust implementations produce identical streams
   double u01() noexcept;
 
+  std::function<int32_t()> m_seeder;
   int32_t m_seed;
   std::mt19937 m_prng;
 };

--- a/test/test_mc.py
+++ b/test/test_mc.py
@@ -6,6 +6,24 @@ import pytest
 import neworder as no
 
 
+def test_nondeterministic_reset() -> None:
+    m = no.Model(no.NoTimeline(), no.MonteCarlo.nondeterministic_stream)
+    seeds = {m.mc.seed()}
+    for _ in range(5):
+        m.mc.reset()
+        seeds.add(m.mc.seed())
+    assert len(seeds) == 6
+
+
+def test_deterministic_reset() -> None:
+    m = no.Model(no.NoTimeline(), no.MonteCarlo.deterministic_identical_stream)
+    seeds = {m.mc.seed()}
+    for _ in range(5):
+        m.mc.reset()
+        seeds.add(m.mc.seed())
+    assert len(seeds) == 1
+
+
 def test_mc_property(base_model: no.Model) -> None:
     base_model.mc.ustream(1)
     base_model.mc.reset()


### PR DESCRIPTION
## Summary

- `MonteCarlo` now stores the seeder as a `std::function<int32_t()>` instead of a plain `int32_t` seed
- `reset()` calls the seeder each time to obtain a fresh seed, so nondeterministic seeders produce a new seed on every reset rather than replaying the original
- `Model` passes a capturing lambda wrapping the `py::function` seeder, keeping it alive by value

## Test plan

- `test_nondeterministic_reset`: creates a model with `nondeterministic_stream`, calls `reset()` 5 times, asserts all 6 seeds (initial + 5 resets) are distinct
- `test_deterministic_reset`: creates a model with `deterministic_identical_stream`, calls `reset()` 5 times, asserts the seed never changes (existing behaviour preserved)
- Full test suite: 48 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)